### PR TITLE
Update flash.py

### DIFF
--- a/flash.py
+++ b/flash.py
@@ -109,7 +109,7 @@ def omg_probe():
 
     if results.OS_DETECTED == "WINDOWS":
         print("<<< PROBING WINDOWS COMPORTS FOR O.MG-CABLE-PROGRAMMER >>>\n")
-        for i in range(1,257):
+        for i in range(1,256):
             try:
                 comport = "COM{PORT}".format(PORT=i)
                 command = [ '--baud', '115200', '--port', comport, '--no-stub', 'chip_id' ]


### PR DESCRIPTION
The default scan range for com ports is set to 1-257. since there are only 256 available ports, it defaults back to the default public set of com ports 1-8. This caused a problem since a large majority of the devices register at 13 or higher by default upon initial connection. By changing line 112 from (1,257) to f(1,256) it now scans all available ports for the user